### PR TITLE
Bugfix - retrieve components from specified workspace

### DIFF
--- a/Ardoq.psm1
+++ b/Ardoq.psm1
@@ -169,8 +169,7 @@ Function Get-ArdoqComponent{
             }
             ELSE
             {
-                #$URI = "$BaseURI/component/search?workspace=$WorkSpaceID"+"?org=$org"
-                $URI = "$BaseURI/component"+"?org=$org"
+                $URI = "$BaseURI/component/fieldsearch?workspace=$WorkSpaceID"+"?org=$org"
             }
         }
     }


### PR DESCRIPTION
With the previous behavior, all components in the whole organization was retrieved.
The proposed change will scope the query to only return components from the specified workspace.